### PR TITLE
feat: 노션 ouath api 개발

### DIFF
--- a/src/main/java/com/example/merging/assistantlist/AssistantId.java
+++ b/src/main/java/com/example/merging/assistantlist/AssistantId.java
@@ -7,10 +7,11 @@ import lombok.Setter;
 
 import java.io.Serializable;
 
+// 복합키 클래스
 @Embeddable
 @Getter
 @Setter
-public class AssistantId implements Serializable { // 복합키 클래스
+public class AssistantId implements Serializable {
 
     @Column(name = "user_email", nullable = false)
     private String userEmail; // 사용자 이메일

--- a/src/main/java/com/example/merging/config/SecurityConfig.java
+++ b/src/main/java/com/example/merging/config/SecurityConfig.java
@@ -32,7 +32,8 @@ public class SecurityConfig {
         http
                 .securityContext(securityContext -> securityContext.requireExplicitSave(false)) // 보안 컨텍스트 관리
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // JWT는 Stateless
-                .authorizeHttpRequests(auth -> auth.requestMatchers("/api/user/join", "/api/user/login", "/api/**").permitAll() // 인증 없이 접근 가능
+                .authorizeHttpRequests(auth -> auth.requestMatchers(
+                        "/api/user/join", "/api/user/login", "/api/**","/api/notion/oauth/callback").permitAll() // 인증 없이 접근 가능
                         .anyRequest().authenticated() // 나머지는 인증 필요
                 )
                 .csrf(csrf -> csrf.disable()) // CSRF 비활성화

--- a/src/main/java/com/example/merging/notion/AuthorizationCodeDTO.java
+++ b/src/main/java/com/example/merging/notion/AuthorizationCodeDTO.java
@@ -1,0 +1,10 @@
+package com.example.merging.notion;
+
+import lombok.Data;
+
+// Notion 인증 과정에서 필요한 Authorization Code 정보를 캡처
+@Data
+public class AuthorizationCodeDTO {
+    private String code; // 노션에서 전달받은 Authorization Code
+    private String state; // 사용자 상태값 (userEmail 및 assistantName)
+}

--- a/src/main/java/com/example/merging/notion/NotionOAuth.java
+++ b/src/main/java/com/example/merging/notion/NotionOAuth.java
@@ -22,7 +22,7 @@ public class NotionOAuth {
     @JoinColumns({@JoinColumn(name = "user_email", referencedColumnName = "user_email"),
             @JoinColumn(name = "assistant_name", referencedColumnName = "assistant_name")
     })
-    private AssistantList assistantList;
+    private AssistantList assistant;
 
     private String accessToken;
     private String refreshToken;
@@ -30,7 +30,6 @@ public class NotionOAuth {
     private String scope; // 권한 범위
     private String workspaceId;
     private String workspaceName;
-    private Integer expiresIn;
 
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt = LocalDateTime.now();

--- a/src/main/java/com/example/merging/notion/NotionOAuthController.java
+++ b/src/main/java/com/example/merging/notion/NotionOAuthController.java
@@ -1,0 +1,50 @@
+package com.example.merging.notion;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/notion/oauth")
+public class NotionOAuthController {
+
+    private final NotionOAuthService notionOAuthService;
+
+    public NotionOAuthController(NotionOAuthService notionOAuthService) {
+        this.notionOAuthService = notionOAuthService;
+    }
+
+    // Authorization URL 요청
+    @GetMapping("/connect")
+    public ResponseEntity<String> connectToNotion(@RequestParam String userEmail, @RequestParam String assistantName) {
+
+        // Notion Authorization URL 생성
+        String authUrl = notionOAuthService.getAuthorizationUrl(userEmail, assistantName);
+
+        // HTTP 302 Redirect 응답
+        return ResponseEntity.status(HttpStatus.FOUND) // 302 상태 코드
+                .header("Location", authUrl) // Location 헤더에 URL 설정
+                .build();
+    }
+
+    // Notion OAuth 콜백 처리
+    @GetMapping("/callback")
+    public ResponseEntity<String> handleCallback(@RequestParam String code, @RequestParam String state) {
+        try {
+            String[] stateParts = state.split(":");
+            String userEmail = stateParts[0];
+            String assistantName = stateParts[1];
+
+            // Authorization Code 처리
+            notionOAuthService.exchangeAuthorizationCode(code, userEmail, assistantName);
+
+            return ResponseEntity.ok("Notion account connected successfully!");
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body("Failed to connect Notion account: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/example/merging/notion/NotionOAuthRepository.java
+++ b/src/main/java/com/example/merging/notion/NotionOAuthRepository.java
@@ -1,0 +1,7 @@
+package com.example.merging.notion;
+
+import com.example.merging.assistantlist.AssistantId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotionOAuthRepository extends JpaRepository<NotionOAuth, AssistantId> {
+}

--- a/src/main/java/com/example/merging/notion/NotionOAuthService.java
+++ b/src/main/java/com/example/merging/notion/NotionOAuthService.java
@@ -1,0 +1,128 @@
+package com.example.merging.notion;
+
+import com.example.merging.assistantlist.AssistantId;
+import com.example.merging.assistantlist.AssistantList;
+import com.example.merging.assistantlist.AssistantListRepository;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+public class NotionOAuthService {
+
+    @Value("${notion.client-id}")
+    private String clientId;
+
+    @Value("${notion.client-secret}")
+    private String clientSecret;
+
+    @Value("${notion.redirect-uri}")
+    private String redirectUri;
+
+    @Value("${notion.token-uri}")
+    private String tokenUri;
+
+    private final RestTemplate restTemplate;
+    private final AssistantListRepository assistantListRepository;
+    private final NotionOAuthRepository notionOAuthRepository;
+
+    public NotionOAuthService(RestTemplate restTemplate, AssistantListRepository assistantListRepository,
+                              NotionOAuthRepository notionOAuthRepository) {
+        this.restTemplate = restTemplate;
+        this.assistantListRepository = assistantListRepository;
+        this.notionOAuthRepository = notionOAuthRepository;
+    }
+
+    // Authorization URL 생성
+    public String getAuthorizationUrl(String userEmail, String assistantName) {
+        String state = userEmail + ":" + assistantName; // 상태값 생성 (userEmail:assistantName)
+
+        // clientId 값 확인
+        if (clientId == null || clientId.isEmpty()) {
+            throw new RuntimeException("CLIENT_ID is not set in application.yml");
+        }
+
+        // Authorization URL 생성
+        return String.format(
+                "https://api.notion.com/v1/oauth/authorize?client_id=%s&response_type=code&owner=user&redirect_uri=%s&state=%s",
+                clientId,
+                redirectUri,
+                state
+        );
+    }
+
+    // Notion에서 받은 Authorization Code를 Access Token으로 교환
+    @Transactional
+    public void exchangeAuthorizationCode(String code, String userEmail, String assistantName) {
+        AssistantId id = new AssistantId(userEmail, assistantName);
+
+        // Assistant 존재 여부 확인
+        AssistantList assistant = assistantListRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Assistant not found for user: " + userEmail));
+
+        // Base64로 client_id와 client_secret 인코딩
+        String credentials = clientId + ":" + clientSecret;
+        String encodedCredentials = Base64.getEncoder().encodeToString(credentials.getBytes());
+
+        // Access Token 요청 헤더 설정
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.add("Authorization", "Basic " + encodedCredentials); // Base64 인코딩된 인증 정보
+        headers.add("Notion-Version", "2022-06-28"); // Notion API 버전
+
+        // 요청 바디 설정
+        Map<String, String> body = new HashMap<>();
+        body.put("grant_type", "authorization_code");
+        body.put("code", code);
+        body.put("redirect_uri", redirectUri);
+
+        HttpEntity<Map<String, String>> request = new HttpEntity<>(body, headers);
+
+        try {
+            // POST 요청 보내기
+            ResponseEntity<NotionTokenResponseDTO> response = restTemplate.postForEntity(
+                    tokenUri, request, NotionTokenResponseDTO.class);
+
+            if (response.getStatusCode().is2xxSuccessful()) {
+                NotionTokenResponseDTO tokenResponseDTO = response.getBody();
+
+                if (tokenResponseDTO == null) {
+                    throw new RuntimeException("Response body is null. Failed to get access token.");
+                }
+
+                // OAuth 정보 저장
+                NotionOAuth notionOAuth = new NotionOAuth();
+                notionOAuth.setId(id);
+                notionOAuth.setAssistant(assistant);
+                notionOAuth.setAccessToken(tokenResponseDTO.getAccess_token());
+                notionOAuth.setRefreshToken(tokenResponseDTO.getRefresh_token());
+                notionOAuth.setTokenType(tokenResponseDTO.getToken_type());
+                notionOAuth.setScope(tokenResponseDTO.getScope());
+                notionOAuth.setWorkspaceId(tokenResponseDTO.getWorkspace_id());
+                notionOAuth.setWorkspaceName(tokenResponseDTO.getWorkspace_name());
+
+                notionOAuthRepository.save(notionOAuth);
+            } else {
+                // HTTP 응답 코드가 2xx가 아닌 경우 처리
+                throw new RuntimeException("Failed to exchange authorization code: " + response.getStatusCode());
+            }
+        } catch (HttpClientErrorException e) {
+            // 401 Unauthorized 또는 다른 HTTP 클라이언트 오류 처리
+            throw new RuntimeException("Failed to connect Notion account: " + e.getStatusCode()
+                    + " on POST request for " + tokenUri + ": " + e.getResponseBodyAsString(), e);
+        } catch (Exception e) {
+            // 기타 예외 처리
+            throw new RuntimeException("Unexpected error while exchanging authorization code: " + e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/com/example/merging/notion/NotionTokenResponseDTO.java
+++ b/src/main/java/com/example/merging/notion/NotionTokenResponseDTO.java
@@ -1,0 +1,14 @@
+package com.example.merging.notion;
+
+import lombok.Data;
+
+// Notion API에서 Access Token 요청 후 반환받는 데이터를 담는 DTO
+@Data
+public class NotionTokenResponseDTO {
+    private String access_token;
+    private String refresh_token;
+    private String workspace_id;
+    private String workspace_name;
+    private String token_type;
+    private String scope;
+}

--- a/src/main/java/com/example/merging/user/UserRepository.java
+++ b/src/main/java/com/example/merging/user/UserRepository.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Repository;
 import java.util.Optional;
 
 @Repository
-public interface UserRepository extends JpaRepository<User, Long> {
+public interface UserRepository extends JpaRepository<User, String> {
 
     Optional<User> findByEmail(String email);
 }


### PR DESCRIPTION
해당 코드는 로컬 테스트용 코드입니다.

### 노션 Integration 설정 방법
나중에 노션 통합에 대해서 값을 변경할 일이 있을 수 있습니다. 
이때 https://www.notion.so/profile/integrations 에 merging 계정으로 접속하여 Integration 관리 창에서  노션 client_id와 client_secret, redirect_uri 값들을 갱신&설정할 수 있습니다.

### 현재 환경에서 DB에 token 저장하는 과정 (Postman)
1. assistant_list 테이블에 임시로 행 하나 입력합니다.
2. `http://localhost:8080/api/notion/oauth/connect`에 아래와 같이 1단계에서 입력한 정보로 param을 넣어서 GET 요청합니다.
    <img width="650" alt="image" src="https://github.com/user-attachments/assets/008afbbd-a43f-42b0-afed-5456df456b2d" />

3. 응답 받은 location header 값으로 브라우저에 접속합니다.
    <img width="650" alt="image" src="https://github.com/user-attachments/assets/d1325550-d79f-4d7f-a576-09e922fd6f8d" />

4. oauth 인증할 페이지들을 선택하고 액세스 요청을 누르면 연결이 완료되어 액세스 토큰이 notion_oauth 테이블에 저장됩니다.

5. 앞으로 노션 api를 사용할 때 해당 토큰을 요청 헤더에 넣어서 사용하면 됩니다.