### PR TITLE
refactor: assistant 삭제하면 연관된 모든 엔티티 자동삭제

### DIFF
--- a/src/main/java/com/example/merging/assistantlist/AssistantList.java
+++ b/src/main/java/com/example/merging/assistantlist/AssistantList.java
@@ -11,6 +11,8 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import com.example.merging.user.User;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import java.util.List;
 
@@ -45,10 +47,12 @@ public class AssistantList {
 
     @JsonManagedReference
     @OneToOne(mappedBy = "assistant", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OnDelete(action = OnDeleteAction.CASCADE) // FK 연결된 엔티티 자동 삭제
     private NotionOAuth notionOAuth;
 
     @JsonManagedReference
     @OneToOne(mappedBy = "assistant", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OnDelete(action = OnDeleteAction.CASCADE) // FK 연결된 엔티티 자동 삭제
     private SlackOAuth slackOAuth;
 
 }

--- a/src/main/java/com/example/merging/notionOAuth/NotionOAuth.java
+++ b/src/main/java/com/example/merging/notionOAuth/NotionOAuth.java
@@ -7,6 +7,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import java.time.LocalDateTime;
 
@@ -24,6 +26,7 @@ public class NotionOAuth {
 
     @JsonBackReference
     @OneToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE) // AssistantList 삭제 시 자동 삭제
     @JoinColumns({
             @JoinColumn(name = "assistant_name", referencedColumnName = "assistantName", nullable = false),
             @JoinColumn(name = "user_email", referencedColumnName = "user_email", nullable = false)

--- a/src/main/java/com/example/merging/slackOAuth/SlackOAuth.java
+++ b/src/main/java/com/example/merging/slackOAuth/SlackOAuth.java
@@ -7,6 +7,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Getter
@@ -22,6 +24,7 @@ public class SlackOAuth {
 
     @JsonBackReference
     @OneToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE) // AssistantList 삭제 시 자동 삭제
     @JoinColumns({
             @JoinColumn(name = "assistant_name", referencedColumnName = "assistantName", nullable = false),
             @JoinColumn(name = "user_email", referencedColumnName = "user_email", nullable = false)


### PR DESCRIPTION
DB에서 assistant_list가 삭제되면 연관된 notion_oauth와 slack_oauth도 자동 삭제되도록 수정했습니다.